### PR TITLE
CoMo v2

### DIFF
--- a/website/static/css/styles.css
+++ b/website/static/css/styles.css
@@ -251,6 +251,17 @@ form.login {
   margin: 80px auto;
 }
 
-.cookie-banner-text form input[type='checkbox'] {
+.cookie-banner-text form .form-rows {
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
   margin-bottom: 25px;
+}
+
+.cookie-banner-text form .form-rows label {
+  flex: 0 0 12em;
+}
+
+.cookie-banner-text form input[type='checkbox'] {
+  margin-right: 5px;
 }

--- a/website/static/js/cookie-banner.js
+++ b/website/static/js/cookie-banner.js
@@ -102,10 +102,14 @@ function onCookieFormSubmit() {
   const form = document.getElementById(COOKIE_CONSENT_FORM);
   const adStorageChecked = form.querySelector("#ad_storage").checked;
   const analyticsChecked = form.querySelector("#analytics_storage").checked;
+  const adUserData = form.querySelector("#ad_user_data").checked;
+  const adPersonalization = form.querySelector("#ad_personalization").checked;
 
   const newConsent = {
     "ad_storage": (adStorageChecked === true) ? "granted" : "denied",
     "analytics_storage": (analyticsChecked === true) ? "granted" : "denied",
+    "ad_user_data": (adUserData === true) ? "granted" : "denied",
+    "ad_personalization": (adPersonalization === true) ? "granted" : "denied",
   }
 
   // update the preferences in the consent cookie

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -27,7 +27,9 @@
         // Default consent is to deny
         gtag("consent", "default", {
           ad_storage: "denied",
-          analytics_storage: "denied"
+          analytics_storage: "denied",
+          ad_user_data: "denied",
+          ad_personalization: "denied"
         });
     </script>
     {% if user %}

--- a/website/templates/cookie-banner.html
+++ b/website/templates/cookie-banner.html
@@ -3,26 +3,36 @@
         <div class="cookie-banner-text">
             <h1>Cookie Settings</h1>
             <form id="cookie-consent-form" onsubmit="onCookieFormSubmit()">
-                <input type="checkbox"
-                       id="ad_storage"
-                       name="ad_storage"
-                       value="granted">
-                <label for="ad_storage"> Ad Storage</label>
-                <input type="checkbox"
-                       id="analytics_storage"
-                       name="analytics_storage"
-                       value="granted">
-                <label for="analytics_storage"> Analytics Storage</label>
-                <input type="checkbox"
-                       id="ad_user_data"
-                       name="ad_user_data"
-                       value="granted">
-                <label for="ad_user_data"> Ad User Data</label>
-                <input type="checkbox"
-                       id="ad_personalization"
-                       name="ad_personalization"
-                       value="granted">
-                <label for="ad_personalization"> Ad Personalization</label>
+                <div class="form-rows">
+                    <label for="ad_storage">
+                        <input type="checkbox"
+                        id="ad_storage"
+                        name="ad_storage"
+                        value="granted">
+                        <span>Ad Storage</span>
+                    </label>
+                    <label for="analytics_storage">
+                        <input type="checkbox"
+                        id="analytics_storage"
+                        name="analytics_storage"
+                        value="granted">
+                        <span>Analytics Storage</span>
+                    </label>
+                    <label for="ad_user_data">
+                        <input type="checkbox"
+                        id="ad_user_data"
+                        name="ad_user_data"
+                        value="granted">
+                        <span>Ad User Data</span>
+                    </label>
+                    <label for="ad_personalization">
+                        <input type="checkbox"
+                        id="ad_personalization"
+                        name="ad_personalization"
+                        value="granted">
+                        <span>Ad Personalization</span>
+                    </label>
+                </div>
                 <div class="cookie-btns">
                     <a class="default btn"
                        href="javascript:;"

--- a/website/templates/cookie-banner.html
+++ b/website/templates/cookie-banner.html
@@ -13,6 +13,16 @@
                        name="analytics_storage"
                        value="granted">
                 <label for="analytics_storage"> Analytics Storage</label>
+                <input type="checkbox"
+                       id="ad_user_data"
+                       name="ad_user_data"
+                       value="granted">
+                <label for="ad_user_data"> Ad User Data</label>
+                <input type="checkbox"
+                       id="ad_personalization"
+                       name="ad_personalization"
+                       value="granted">
+                <label for="ad_personalization"> Ad Personalization</label>
                 <div class="cookie-btns">
                     <a class="default btn"
                        href="javascript:;"


### PR DESCRIPTION
Upgraded example website to enable Consent Mode v2 by adding `ad_user_data` and `ad_personalization` fields (more info [here](https://developers.google.com/tag-platform/security/guides/consent?tab=tag-manager#upgrade-consent-v2)).